### PR TITLE
Fix issue body being nil and not handled properly

### DIFF
--- a/issues_filters.go
+++ b/issues_filters.go
@@ -58,6 +58,10 @@ func FilterClosedByPull(issues []*github.Issue) []*github.Issue {
 			continue
 		}
 
+		if issue.Body == nil {
+			continue
+		}
+
 		matches := r.FindStringSubmatch(*issue.Body)
 		if matches != nil {
 			num, _ := strconv.Atoi(matches[len(matches)-1])


### PR DESCRIPTION
Fix issue when an issue or pull request body is empty, and the property is `nil` in the GitHub response. Incorrectly assumed the body was empty string when empty.